### PR TITLE
Add types file to exports

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -16,6 +16,7 @@
     "dist"
   ],
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.js",
     "import": "./dist/index.mjs"
   },


### PR DESCRIPTION
Fixes ```error TS7016: Could not find a declaration file for module 'vuemoji-picker'. '<path>/vuemoji-picker/dist/index.mjs' implicitly has an 'any' type.
  There are types at '<PATH>/vuemoji-picker/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vuemoji-picker' library may need to update its package.json or typings.```